### PR TITLE
Fix typo in the license name.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,9 +11,12 @@ setup(
     description="URL decorator for django views",
     long_description=long_description,
     long_description_content_type="text/markdown",
-    license='APGL-3.0',
+    license='AGPL-3.0-only',
     author='isik-kaplan',
     author_email='',
     python_requires=">=3.5",
-    install_requires=['django>=2.0']
+    install_requires=['django>=2.0'],
+    classifiers=[
+        'License :: OSI Approved :: GNU Affero General Public License v3'
+    ],
 )


### PR DESCRIPTION
The license field was probably supposed to read "AGPL-3.0" rather than
"APGL-3.0". Use an SPDX identifier as well as a Trove classifier to make
it easy for automated tools to figure out what the license is.